### PR TITLE
Remove needless typeof undefinded

### DIFF
--- a/util.js
+++ b/util.js
@@ -51,7 +51,7 @@ const getUniqueBusNameSync = function(bus, name) {
     if (name[0] == ':')
         return name;
 
-    if (typeof bus === "undefined" || !bus)
+    if (!bus)
         bus = Gio.DBus.session;
 
     let variant_name = new GLib.Variant("(s)", [name]);
@@ -63,7 +63,7 @@ const getUniqueBusNameSync = function(bus, name) {
 }
 
 var traverseBusNames = function(bus, cancellable, callback) {
-    if (typeof bus === "undefined" || !bus)
+    if (!bus)
         bus = Gio.DBus.session;
 
     if (typeof(callback) !== "function")
@@ -90,7 +90,7 @@ var traverseBusNames = function(bus, cancellable, callback) {
 }
 
 var introspectBusObject = function(bus, name, cancellable, filterFunction, targetCallback, path) {
-    if (typeof path === "undefined" || !path)
+    if (!path)
         path = "/";
 
     if (typeof targetCallback !== "function")
@@ -106,7 +106,7 @@ var introspectBusObject = function(bus, name, cancellable, filterFunction, targe
                 let node_info = Gio.DBusNodeInfo.new_for_xml(introspection);
 
                 if ((typeof filterFunction === "function" && filterFunction(node_info) === true) ||
-                    typeof filterFunction === "undefined" || !filterFunction) {
+                    !filterFunction) {
                     targetCallback(name, path);
                 }
 


### PR DESCRIPTION
Optimize expression

```
typeof x === "undefined" || !x
```
equal

```
!x
```
because

```
!undefined// true
```